### PR TITLE
Fix owner names

### DIFF
--- a/bill.toml
+++ b/bill.toml
@@ -1,6 +1,12 @@
 description = "Ting Bill YYYY-MM-DD"
 
-deviceIds = [ "1112223333", "1112224444", "1112220000" ]
+# deviceIds = [ "1112223333", "1112224444", "1112220000" ]
+
+[devices]
+1112223333 = "owner1"
+1112224444 = "owner2"
+1112220000 = "owner2"
+
 shortStrawId = "1112220000"
 
 total = 118.84

--- a/bill.toml
+++ b/bill.toml
@@ -1,17 +1,15 @@
 description = "Ting Bill YYYY-MM-DD"
 
-# deviceIds = [ "1112223333", "1112224444", "1112220000" ]
-
 [devices]
-1112223333 = "owner1"
-1112224444 = "owner2"
-1112220000 = "owner2"
+"1112223333" = "owner1"
+"1112224444" = "owner2"
+"1112220000" = "owner2"
 
 shortStrawId = "1112220000"
 
 total = 118.84
 
-devices = 42.00
+devicesCost = 42.00
 
 minutes = 35.00
 messages = 8.00

--- a/bill.toml
+++ b/bill.toml
@@ -1,19 +1,5 @@
 description = "Ting Bill YYYY-MM-DD"
 
-[[devices]]
-deviceId = "1112223333"
-owner = "owner1"
-
-[[devices]]
-deviceId = "1112224444"
-owner = "owner2"
-
-[[devices]]
-deviceId = "1112220000"
-owner = "owner2"
-
-shortStrawId = "1112220000"
-
 total = 118.84
 
 devicesCost = 42.00
@@ -27,3 +13,17 @@ extraMessages = 2.00
 extraMegabytes = 3.00
 
 fees = 28.74
+
+shortStrawId = "1112220000"
+
+[[devices]]
+deviceId = "1112223333"
+owner = "owner1"
+
+[[devices]]
+deviceId = "1112224444"
+owner = "owner2"
+
+[[devices]]
+deviceId = "1112220000"
+owner = "owner2"

--- a/bill.toml
+++ b/bill.toml
@@ -1,9 +1,16 @@
 description = "Ting Bill YYYY-MM-DD"
 
-[devices]
-"1112223333" = "owner1"
-"1112224444" = "owner2"
-"1112220000" = "owner2"
+[[devices]]
+deviceId = "1112223333"
+owner = "owner1"
+
+[[devices]]
+deviceId = "1112224444"
+owner = "owner2"
+
+[[devices]]
+deviceId = "1112220000"
+owner = "owner2"
 
 shortStrawId = "1112220000"
 

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -28,6 +28,18 @@ func (b bill) deviceIds() []string {
 	return deviceIds
 }
 
+func (b bill) ownerById(id string) string {
+	o := "Unknown"
+
+	for _, d := range b.Devices {
+		if id == d.DeviceId {
+			o = d.Owner
+		}
+	}
+
+	return o
+}
+
 type device struct {
 	DeviceId string
 	Owner    string
@@ -421,7 +433,7 @@ func createBillFile(path string) {
 	// to "hand-craft" the example toml. So we can group values in a sensible way
 	// and provide helpful comment text
 	newBill := bill{
-		Description: "Ting Bill YYYY-MM-DD",
+		Description: "Ting Bill Split YYYY-MM-DD",
 		Devices: []device{
 			device{
 				DeviceId: "1112223333",
@@ -590,7 +602,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 	//   (for comparison), Usage subtotal, Devices Subtotal, Tax+Reg subtotal"
 	headingTable := func(b bill, bs billSplit) {
 		pageHeading := []string{"Invoice with date", "Devices Qty", "$Total", "$Calc", "$Usage", "$Devices", "$Tax+Reg"}
-		w := []float64{40.0, 25.0, 20.0, 20.0, 20.0, 20.0, 20.0}
+		w := []float64{65.0, 25.0, 20.0, 20.0, 20.0, 20.0, 20.0}
 
 		// Print heading
 		for j, str := range pageHeading {
@@ -673,7 +685,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 
 		for _, id := range deviceIds {
 			values[id] = usageTableVals{
-				"TODO: Owner",
+				b.ownerById(id),
 				strconv.Itoa(bs.MinuteQty[id]),
 				strconv.Itoa(bs.MessageQty[id]),
 				strconv.Itoa(bs.MegabyteQty[id]),
@@ -875,7 +887,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 		for _, id := range deviceIds {
 			userTotal := decimal.Sum(bs.MinuteCosts[id], bs.MessageCosts[id], bs.MegabyteCosts[id], bs.SharedCosts[id])
 			values[id] = splitTableVals{
-				"TODO: Owner",
+				b.ownerById(id),
 				bs.MinuteCosts[id].StringFixed(2),
 				bs.MessageCosts[id].StringFixed(2),
 				bs.MegabyteCosts[id].StringFixed(2),

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -401,6 +401,8 @@ func createNewBillingDir(args []string) {
 			fmt.Printf("\n1. Enter values for the bill.toml file in new directory `%s`\n", newDirName)
 			fmt.Println("2. Add csv files for minutes, message, megabytes in the new directory")
 			fmt.Printf("3. run `ting-bill-split dir %s`\n", newDirName)
+		} else {
+			fmt.Println("Directory already exists.")
 		}
 	}
 }

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -424,7 +424,6 @@ func createBillFile(path string) {
 		panic(err)
 	}
 
-	// TODO - fix this NOW
 	// TODO - instead of encoding the struct, maybe define the newBill to ensure we
 	// don't forget to create requisite parts in the toml, but then use the newBill
 	// to "hand-craft" the example toml. So we can group values in a sensible way

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -18,25 +18,37 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+func (b bill) deviceIds() []string {
+	deviceIds := make([]string, len(b.Devices))
+
+	i := 0
+	for k := range b.Devices {
+		deviceIds[i] = k
+		i++
+	}
+
+	return deviceIds
+}
+
 // Used to represent the Ting-provided and user-provided info required to split bill costs
 type bill struct {
-	Description    string   `toml:"description"`
-	DeviceIds      []string `toml:"deviceIds"`
-	ShortStrawID   string   `toml:"shortStrawId"`
-	Total          float64  `toml:"total"`
-	Devices        float64  `toml:"devices"`
-	Minutes        float64  `toml:"minutes"`
-	Messages       float64  `toml:"messages"`
-	Megabytes      float64  `toml:"megabytes"`
-	ExtraMinutes   float64  `toml:"extraMinutes"`
-	ExtraMessages  float64  `toml:"extraMessages"`
-	ExtraMegabytes float64  `toml:"extraMegabytes"`
-	Fees           float64  `toml:"fees"`
+	Description    string            `toml:"description"`
+	Devices        map[string]string `toml:"devices"`
+	ShortStrawID   string            `toml:"shortStrawId"`
+	Total          float64           `toml:"total"`
+	DevicesCost    float64           `toml:"devices"`
+	Minutes        float64           `toml:"minutes"`
+	Messages       float64           `toml:"messages"`
+	Megabytes      float64           `toml:"megabytes"`
+	ExtraMinutes   float64           `toml:"extraMinutes"`
+	ExtraMessages  float64           `toml:"extraMessages"`
+	ExtraMegabytes float64           `toml:"extraMegabytes"`
+	Fees           float64           `toml:"fees"`
 }
 
 // Used to contain all subtotals for a monthly bill.
 // MinuteCosts, MessageCosts, MegabyteCosts are maps of decimal.Decimal totals.
-// They are split by bill.DeviceIds and calculated by usage in parseMaps.
+// They are split by bill.Devices and calculated by usage in parseMaps.
 // SharedCosts reflect the rest of the items not based on usage, which get split evenly across all deviceIds
 // TODO: finish these comments
 type billSplit struct {
@@ -77,8 +89,8 @@ func parseMaps(min map[string]int, msg map[string]int, meg map[string]int, bil b
 	bilMinutes := decimal.NewFromFloat(bil.Minutes + bil.ExtraMinutes)
 	bilMessages := decimal.NewFromFloat(bil.Messages + bil.ExtraMessages)
 	bilMegabytes := decimal.NewFromFloat(bil.Megabytes + bil.ExtraMegabytes)
-	delta := decimal.NewFromFloat(bil.Devices + bil.Fees).Round(DecimalPrecision)
-	deviceQty := decimal.New(int64(len(bil.DeviceIds)), 0)
+	delta := decimal.NewFromFloat(bil.DevicesCost + bil.Fees).Round(DecimalPrecision)
+	deviceQty := decimal.New(int64(len(bil.Devices)), 0)
 
 	// Calculate usage totals
 	for _, v := range min {
@@ -97,6 +109,7 @@ func parseMaps(min map[string]int, msg map[string]int, meg map[string]int, bil b
 	totalMsg := decimal.New(int64(usedMsg), DecimalPrecision)
 	totalMeg := decimal.New(int64(usedMeg), DecimalPrecision)
 
+	// TODO - fix this NOW
 	for _, id := range bil.DeviceIds {
 		subMin := decimal.New(int64(min[id]), DecimalPrecision)
 		bs.MinutePercent[id] = subMin.Div(totalMin)
@@ -192,10 +205,14 @@ func parseBill(r io.Reader) (bill, error) {
 		return bill{}, err
 	}
 
-	phoneIndex := sliceIndex(len(b.DeviceIds), func(i int) bool { return b.DeviceIds[i] == b.ShortStrawID })
+	ids := b.deviceIds()
+
+	// Check to see if a shortStrawId was set. If not, set it to first one we find. Map
+	// ordering is random, so deal with it.
+	phoneIndex := sliceIndex(len(ids), func(i int) bool { return ids[i] == b.ShortStrawID })
 
 	if phoneIndex < 0 {
-		b.ShortStrawID = b.DeviceIds[0]
+		b.ShortStrawID = ids[0]
 	}
 
 	return b, nil
@@ -389,12 +406,17 @@ func createBillFile(path string) {
 		panic(err)
 	}
 
+	// TODO - fix this NOW - NEXT - why isn't this a bill??
 	newBill := bill{
-		Description:    "Ting Bill YYYY-MM-DD",
-		DeviceIds:      []string{"1112223333", "2229998888", "etc"},
+		Description: "Ting Bill YYYY-MM-DD",
+		Devices: map[string]string{
+			"1112223333": "owner1",
+			"2229998888": "owner2",
+			"3331119999": "owner1",
+		},
 		ShortStrawID:   "1112223333",
 		Total:          0.00,
-		Devices:        0.00,
+		DevicesCost:    0.00,
 		Minutes:        0.00,
 		Messages:       0.00,
 		Megabytes:      0.00,
@@ -579,11 +601,11 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 
 		values := []string{
 			b.Description,
-			strconv.Itoa(len(b.DeviceIds)),
+			strconv.Itoa(len(b.Devices)),
 			strconv.FormatFloat(b.Total, 'f', 2, 64),
 			calcCost.StringFixed(2),
 			usgCost.StringFixed(2),
-			strconv.FormatFloat(b.Devices, 'f', 2, 64),
+			strconv.FormatFloat(b.DevicesCost, 'f', 2, 64),
 			strconv.FormatFloat(b.Fees, 'f', 2, 64),
 		}
 
@@ -625,6 +647,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 		// Prep data
 		values := make(map[string]usageTableVals)
 
+		// TODO - fix this NOW
 		for _, id := range b.DeviceIds {
 			values[id] = usageTableVals{
 				"TODO: Owner",
@@ -765,12 +788,12 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 		pdf.Ln(-1)
 
 		// Prep data
-		sTotal := strconv.FormatFloat(b.Devices+b.Fees, 'f', 2, 64)
+		sTotal := strconv.FormatFloat(b.DevicesCost+b.Fees, 'f', 2, 64)
 
 		values := []sharedTableVals{
 			{
 				costType: "Devices",
-				amount:   strconv.FormatFloat(b.Devices, 'f', 2, 64),
+				amount:   strconv.FormatFloat(b.DevicesCost, 'f', 2, 64),
 			},
 			{
 				costType: "Tax & Reg",
@@ -824,6 +847,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 		// Prep data
 		values := make(map[string]splitTableVals)
 
+		// TODO - fix this NOW
 		for _, id := range b.DeviceIds {
 			userTotal := decimal.Sum(bs.MinuteCosts[id], bs.MessageCosts[id], bs.MegabyteCosts[id], bs.SharedCosts[id])
 			values[id] = splitTableVals{

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -222,9 +222,6 @@ func parseBill(r io.Reader) (bill, error) {
 	}
 
 	ids := b.deviceIds()
-	fmt.Println("DEBUGGGGGGING")
-	fmt.Println(ids)
-	fmt.Println(b)
 
 	// Check to see if a shortStrawId was set. If not, set it to first one we find. Map
 	// ordering is random, so deal with it.

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -626,7 +626,7 @@ func generatePDF(bs billSplit, b bill, filePath string) (string, error) {
 
 		for _, id := range b.DeviceIds {
 			values[id] = usageTableVals{
-				"TODO: Owner Name",
+				"TODO: Owner",
 				strconv.Itoa(bs.MinuteQty[id]),
 				strconv.Itoa(bs.MessageQty[id]),
 				strconv.Itoa(bs.MegabyteQty[id]),

--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -21,29 +21,32 @@ import (
 func (b bill) deviceIds() []string {
 	deviceIds := make([]string, len(b.Devices))
 
-	i := 0
-	for k := range b.Devices {
-		deviceIds[i] = k
-		i++
+	for i, d := range b.Devices {
+		deviceIds[i] = d.DeviceId
 	}
 
 	return deviceIds
 }
 
+type device struct {
+	DeviceId string
+	Owner    string
+}
+
 // Used to represent the Ting-provided and user-provided info required to split bill costs
 type bill struct {
-	Description    string            `toml:"description"`
-	Devices        map[string]string `toml:"devices"`
-	ShortStrawID   string            `toml:"shortStrawId"`
-	Total          float64           `toml:"total"`
-	DevicesCost    float64           `toml:"devicesCost"`
-	Minutes        float64           `toml:"minutes"`
-	Messages       float64           `toml:"messages"`
-	Megabytes      float64           `toml:"megabytes"`
-	ExtraMinutes   float64           `toml:"extraMinutes"`
-	ExtraMessages  float64           `toml:"extraMessages"`
-	ExtraMegabytes float64           `toml:"extraMegabytes"`
-	Fees           float64           `toml:"fees"`
+	Description    string   `toml:"description"`
+	Devices        []device `toml:"devices"`
+	ShortStrawID   string   `toml:"shortStrawId"`
+	Total          float64  `toml:"total"`
+	DevicesCost    float64  `toml:"devicesCost"`
+	Minutes        float64  `toml:"minutes"`
+	Messages       float64  `toml:"messages"`
+	Megabytes      float64  `toml:"megabytes"`
+	ExtraMinutes   float64  `toml:"extraMinutes"`
+	ExtraMessages  float64  `toml:"extraMessages"`
+	ExtraMegabytes float64  `toml:"extraMegabytes"`
+	Fees           float64  `toml:"fees"`
 }
 
 // Used to contain all subtotals for a monthly bill.
@@ -417,10 +420,19 @@ func createBillFile(path string) {
 	// and provide helpful comment text
 	newBill := bill{
 		Description: "Ting Bill YYYY-MM-DD",
-		Devices: map[string]string{
-			"1112223333": "owner1",
-			"2229998888": "owner2",
-			"3331119999": "owner1",
+		Devices: []device{
+			device{
+				DeviceId: "1112223333",
+				Owner:    "owner1",
+			},
+			device{
+				DeviceId: "2229998888",
+				Owner:    "owner2",
+			},
+			device{
+				DeviceId: "3331119999",
+				Owner:    "owner1",
+			},
 		},
 		ShortStrawID:   "1112223333",
 		Total:          0.00,

--- a/ting-bill-split_test.go
+++ b/ting-bill-split_test.go
@@ -226,18 +226,25 @@ extraMinutes = 1.00
 extraMessages = 2.00
 extraMegabytes = 3.00
 fees = 12.84
-deviceIds = [ "1112223333", "1112224444", "1112220000" ]
+[devices]
+1112223333 = "owner1"
+1112224444 = "owner2"
+1112220000 = "owner2"
 shortStrawId = "1112220000"`,
 			bill{
 				Minutes:        35.00,
 				Messages:       8.00,
 				Megabytes:      20.00,
-				Devices:        42.00,
+				DevicesCost:    42.00,
 				ExtraMinutes:   1.00,
 				ExtraMessages:  2.00,
 				ExtraMegabytes: 3.00,
 				Fees:           12.84,
-				DeviceIds:      []string{"1112223333", "1112224444", "1112220000"},
+				Devices:        {
+					"1112223333": "owner1",
+					"1112224444": "owner2",
+					"1112220000": "owner2",
+				},
 				ShortStrawID:   "1112220000",
 			},
 		},
@@ -250,18 +257,25 @@ extraMinutes = 1.00
 extraMessages = 2.00
 extraMegabytes = 3.00
 fees = 12.84
-deviceIds = [ "1112223333", "1112224444", "1112220000" ]
+[devices]
+1112223333 = "owner1"
+1112224444 = "owner2"
+1112220000 = "owner2"
 shortStrawId = "wrongnumber"`,
 			bill{
 				Minutes:        35.00,
 				Messages:       8.00,
 				Megabytes:      20.00,
-				Devices:        42.00,
+				DevicesCost:    42.00,
 				ExtraMinutes:   1.00,
 				ExtraMessages:  2.00,
 				ExtraMegabytes: 3.00,
 				Fees:           12.84,
-				DeviceIds:      []string{"1112223333", "1112224444", "1112220000"},
+				Devices:        {
+					"1112223333": "owner1",
+					"1112224444": "owner2",
+					"1112220000": "owner2",
+				},
 				ShortStrawID:   "1112223333",
 			},
 		},
@@ -274,17 +288,24 @@ extraMinutes = 1.00
 extraMessages = 2.00
 extraMegabytes = 3.00
 fees = 12.84
-deviceIds = [ "1112223333", "1112224444", "1112220000" ]`,
+[devices]
+1112223333 = "owner1"
+1112224444 = "owner2"
+1112220000 = "owner2"`,
 			bill{
 				Minutes:        35.00,
 				Messages:       8.00,
 				Megabytes:      20.00,
-				Devices:        42.00,
+				DevicesCost:    42.00,
 				ExtraMinutes:   1.00,
 				ExtraMessages:  2.00,
 				ExtraMegabytes: 3.00,
 				Fees:           12.84,
-				DeviceIds:      []string{"1112223333", "1112224444", "1112220000"},
+				Devices:        {
+					"1112223333": "owner1",
+					"1112224444": "owner2",
+					"1112220000": "owner2",
+				},
 				ShortStrawID:   "1112223333",
 			},
 		},
@@ -323,16 +344,16 @@ func TestParseMaps(t *testing.T) {
 				"1112223333": 8001,
 				"1112224444": 2999,
 			},
-			bill{
+				DevicesCost:    42.00,
 				Minutes:        35.00,
 				Messages:       8.00,
 				Megabytes:      20.00,
-				Devices:        42.00,
-				ExtraMinutes:   1.00,
+				DevicesCost:    42.00,
+				Devices:        []string{"1112223333", "1112224444", "1112220000"},
 				ExtraMessages:  2.00,
 				ExtraMegabytes: 3.00,
 				Fees:           12.85,
-				DeviceIds:      []string{"1112223333", "1112224444", "1112220000"},
+				Devices:        []string{"1112223333", "1112224444", "1112220000"},
 				ShortStrawID:   "1112220000",
 				Total:          118.84,
 			},


### PR DESCRIPTION
Previously, the reports would show "TODO: Owner" in the corresponding columns.
Now, we can assign an owner to each device, and thus show them in any reports.

Resolves #22 