### PR TITLE
Fix "new directory" permissions for Linux

### DIFF
--- a/ting-bill-split.go
+++ b/ting-bill-split.go
@@ -406,7 +406,7 @@ func createNewBillingDir(args []string) {
 		}
 		if _, err := os.Stat(newDirName); os.IsNotExist(err) {
 			fmt.Println("Creating a directory for a new billing period.")
-			os.MkdirAll(newDirName, os.ModeDir)
+			os.MkdirAll(newDirName, os.ModePerm)
 			createBillFile(newDirName)
 			fmt.Printf("\n1. Enter values for the bill.toml file in new directory `%s`\n", newDirName)
 			fmt.Println("2. Add csv files for minutes, message, megabytes in the new directory")


### PR DESCRIPTION
On Linux, "ting-bill-split new" fails with a permission error
creating the bill.toml template. The created directory grants no
write privs. There is no workaround.

This is a minimal change to allow the template file to be built.

closes #37