### PR TITLE
i33 provide csv output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,13 @@
-# ting-bill-split directories
-invoices/
-
-# binaries
+# binaries old and new
 ting-bill-split
+**/tingbill
 
 # Handy spot to try with real usage files
 real-bills/
 
-# Project-specific binary files
+# Generated report files
 **/*.pdf
+**/*split.csv
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ _testmain.go
 # Editor noise
 **.swp
 **.code-workspace
+
+# OS noise
+**/*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ real-bills/
 
 # Generated report files
 **/*.pdf
-**/*split.csv
+**/*report.csv
 
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ting-bill-split / `tingbill`
-Split your Ting bills based on usage for each device.
+Split your Ting bills based on usage for each device. Generates ***both*** PDF and CSV reports by default.
 
 ## Summary
 Ting provides cellular service in the United States using Sprint, T-Mobile, and Verizon networks - [Wikipedia](https://en.wikipedia.org/wiki/Ting_Inc.)
@@ -74,13 +74,13 @@ The default method for splitting bills is to work with directories in "batch mod
       ```
       tingbill dir .
       ```
-1. Review the resulting `.pdf` file in the bill split directory you chose.
+1. Review the resulting `.pdf` and `.csv` report files in the bill split directory you chose.
 1. For each following month's bill, you can either:
    * Start again at **_step #2_**
    * Make a new directory manually, copy the previous month's `bill.toml` into it, start at **_step #3_**
 
 ## Breakdown of `bill.toml` Info
-* **`description`** - Ideally this is a unique string of characters, I recommend including the billing date. This description is used as part of the resulting `.pdf` file after calculating the bill split.
+* **`description`** - Ideally this is a unique string of characters, I recommend including the billing date. This description is used as part of the resulting `.pdf` and `.csv` report files after calculating the bill split.
 * **`deviceIds`** - Each string is a unique phone number on the Ting plan.
    * **_NOTE_**: do NOT use dashes. _Example_: `"1112223333"`, not `"111-222-3333"`.
 * `shortStrawId` - In the unlikely event a cost can't be split evenly between lines, this is the line that will absorb that cost. It's usually $0.01, and I usually use the plan owner's number (probably you!). This is due to math, our inability to split pennies in half, and partially a personal judgement call based on complexity and ROI :)

--- a/cmd/tingbill/main.go
+++ b/cmd/tingbill/main.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/hitjim/ting-bill-split/internal/tingcsv"
+
 	"github.com/hitjim/ting-bill-split/internal/tingbill"
 	"github.com/hitjim/ting-bill-split/internal/tingparse"
 	"github.com/hitjim/ting-bill-split/internal/tingpdf"
@@ -37,7 +39,7 @@ func createNewBillingDir(args []string) {
 			createBillFile(newDirName)
 			fmt.Printf("\n1. Enter values for the bill.toml file in new directory `%s`\n", newDirName)
 			fmt.Println("2. Add csv files for minutes, message, megabytes in the new directory")
-			fmt.Printf("3. run `ting-bill-split dir %s`\n", newDirName)
+			fmt.Printf("3. run `tingbill dir %s`\n", newDirName)
 		} else {
 			fmt.Println("Directory already exists.")
 		}
@@ -201,19 +203,25 @@ func parseDir(path string) {
 		}
 
 		pdfFilePath := filepath.Join(path, billData.Description+".pdf")
-
 		invoiceName, err := tingpdf.GeneratePDF(split, billData, pdfFilePath)
 		if err != nil {
-			fmt.Printf("Failed to generate invoice at path: %v\n\n", pdfFilePath)
+			fmt.Printf("Failed to generate PDF invoice at path: %v\n\n", pdfFilePath)
 			log.Fatal(err)
 		}
-		fmt.Printf("Invoice generation complete: %s\n\n", invoiceName)
+		fmt.Printf("PDF invoice generation complete: %s\n\n", invoiceName)
+
+		csvFilePath := filepath.Join(path, billData.Description+"_report.csv")
+		invoiceName, err = tingcsv.GenerateCSV(split, billData, csvFilePath)
+		if err != nil {
+			fmt.Printf("Failed to generate CSV record at path: %v\n\n", csvFilePath)
+			log.Fatal(err)
+		}
 	}
 }
 
 func printUsageHelp() {
-	fmt.Println("Use `ting-bill-split new` or `ting-bill-split new <billing-directory>` to create a new billing directory")
-	fmt.Println("\nUse `ting-bill-split dir <billing-directory>` to run on a directory containing a `bill.toml`, and CSV files for minutes, messages, and megabytes usage.")
+	fmt.Println("Use `tingbill new` or `tingbill new <billing-directory>` to create a new billing directory")
+	fmt.Println("\nUse `tingbill dir <billing-directory>` to run on a directory containing a `bill.toml`, and CSV files for minutes, messages, and megabytes usage.")
 	fmt.Println("  Each of these files must contain their type somewhere in the filename - i.e. `YYYYMMDD-messages.csv` or `messages-potatosalad.csv` or whatever.")
 }
 

--- a/internal/tingcsv/tingcsv.go
+++ b/internal/tingcsv/tingcsv.go
@@ -13,6 +13,7 @@ import (
 // GenerateCSV accepts a tingbill.BillSplit, tingbill.Bill, filepath string, and returns a string
 // containing a filepath for the newly generated Ting Bill Split CSV, and an error.
 // The tingbill.Bill should be the same one that generated the tingbill.BillSplit
+// The first value in a table's header row will **Have Asterisks**
 func GenerateCSV(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (string, error) {
 	fmt.Printf("\nGenerating invoice CSV...\n")
 	const RoundPrecision = int32(2)
@@ -55,37 +56,116 @@ func GenerateCSV(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	usgCost := decimal.Sum(minCosts, msgCosts, megCosts).Round(RoundPrecision)
 
 	records := [][]string{
-		{"Invoice with date", "Devices Qty", "$Total", "$Calc", "$Usage", "$Devices", "$Tax+Reg"},
-		{b.Description,
+		{"**Invoice with date**", "Devices Qty", "$Total", "$Calc", "$Usage", "$Devices", "$Tax+Reg"},
+		{
+			b.Description,
 			strconv.Itoa(len(b.Devices)),
 			strconv.FormatFloat(b.Total, 'f', 2, 64),
 			calcCost.StringFixed(2),
 			usgCost.StringFixed(2),
 			strconv.FormatFloat(b.DevicesCost, 'f', 2, 64),
-			strconv.FormatFloat(b.Fees, 'f', 2, 64)},
+			strconv.FormatFloat(b.Fees, 'f', 2, 64),
+		},
 	}
 
 	// Table 1: Usage - 8 columns, <deviceID qty>+1 rows
 	// heading: number, nickname?, min, msg, data (KB), min%, msg%, data%
 	// Then entries for each number
 	// then entry for "Total" under nickname, and rest of sums
+	records = append(records, []string{"**Phone Number**", "Owner", "Minutes", "Messages", "Data (KB)", "Min%", "Msg%", "Data%"})
 
-	// Table 2: Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
-	// heading: Weighted Costs: Minutes, Messages, Data
+	// Prep data
+	ids := b.DeviceIds()
+
+	for _, id := range ids {
+		records = append(records, []string{
+			id,
+			b.OwnerByID(id),
+			strconv.Itoa(bs.MinuteQty[id]),
+			strconv.Itoa(bs.MessageQty[id]),
+			strconv.Itoa(bs.MegabyteQty[id]),
+			bs.MinutePercent[id].StringFixed(RoundPrecision),
+			bs.MessagePercent[id].StringFixed(RoundPrecision),
+			bs.MegabytePercent[id].StringFixed(RoundPrecision),
+		})
+	}
+
+	// Table 2: Weighted Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
+	// heading: Weighted: Minutes, Messages, Data
 	// Base: $x, $y, $z
 	// Extra: etc
 	// Total: etc (sum of Min, Msg, Data gets tacked on as extra cell/col on final row)
 
+	// Prep data
+	totalMin := b.Minutes + b.ExtraMinutes
+	totalMsg := b.Messages + b.ExtraMessages
+	totalMeg := b.Megabytes + b.ExtraMegabytes
+	wTotal := strconv.FormatFloat(totalMin+totalMsg+totalMeg, 'f', 2, 64)
+
+	records = append(records, []string{"**Weighted**", "Minutes", "Messages", "Data"},
+		[]string{
+			"Base",
+			strconv.FormatFloat(b.Minutes, 'f', 2, 64),
+			strconv.FormatFloat(b.Messages, 'f', 2, 64),
+			strconv.FormatFloat(b.Megabytes, 'f', 2, 64),
+		},
+		[]string{
+			"Extra",
+			strconv.FormatFloat(b.ExtraMinutes, 'f', 2, 64),
+			strconv.FormatFloat(b.ExtraMessages, 'f', 2, 64),
+			strconv.FormatFloat(b.ExtraMegabytes, 'f', 2, 64),
+		},
+		[]string{
+			"Total",
+			strconv.FormatFloat(totalMin, 'f', 2, 64),
+			strconv.FormatFloat(totalMsg, 'f', 2, 64),
+			strconv.FormatFloat(totalMeg, 'f', 2, 64),
+			wTotal,
+		},
+	)
+
 	// Table 3: Shared costs - 2 columns, 4 rows
-	// heading: Type, Amount
+	// heading: Shared, Amount
 	// Devices: $
 	// Tax & Reg: $
 	// Total: $
+	sTotal := strconv.FormatFloat(b.DevicesCost+b.Fees, 'f', 2, 64)
+
+	records = append(records, []string{"**Shared**", "Amount"},
+		[]string{
+			"Devices",
+			strconv.FormatFloat(b.DevicesCost, 'f', 2, 64),
+		},
+		[]string{
+			"Tax & Reg",
+			strconv.FormatFloat(b.Fees, 'f', 2, 64),
+		},
+		[]string{
+			"Total",
+			sTotal,
+		},
+	)
 
 	// Table 4: Costs split - 7 columns, <deviceID qty>+1 rows
 	// heading: number, Nickname, Min, Msg, Data, Shared, Total
 	// entry for each number
+	records = append(records, []string{"**Phone Number**", "Owner", "$Min", "$Msg", "$Data", "$Shared", "$Total"})
 
+	for _, id := range ids {
+		userTotal := decimal.Sum(bs.MinuteCosts[id], bs.MessageCosts[id], bs.MegabyteCosts[id], bs.SharedCosts[id])
+
+		records = append(records, []string{
+			id,
+			b.OwnerByID(id),
+			bs.MinuteCosts[id].StringFixed(2),
+			bs.MessageCosts[id].StringFixed(2),
+			bs.MegabyteCosts[id].StringFixed(2),
+			bs.SharedCosts[id].StringFixed(2),
+			userTotal.StringFixed(2),
+		})
+	}
+
+	// Records complete, write to CSV
 	err = writer.WriteAll(records)
 
 	return filePath, err

--- a/internal/tingcsv/tingcsv.go
+++ b/internal/tingcsv/tingcsv.go
@@ -1,9 +1,13 @@
 package tingcsv
 
 import (
+	"encoding/csv"
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/hitjim/ting-bill-split/internal/tingbill"
+	"github.com/shopspring/decimal"
 )
 
 // GenerateCSV accepts a tingbill.BillSplit, tingbill.Bill, filepath string, and returns a string
@@ -11,30 +15,78 @@ import (
 // The tingbill.Bill should be the same one that generated the tingbill.BillSplit
 func GenerateCSV(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (string, error) {
 	fmt.Printf("\nGenerating invoice CSV...\n")
-	RoundPrecision := int32(2)
+	const RoundPrecision = int32(2)
 
-	// Table 0: Heading - 7 rows
+	// Bail right away if we can't write the CSV file
+	csvFile, err := os.Create(filePath)
+	if err != nil {
+		return filePath, err
+	}
+	defer csvFile.Close()
+
+	writer := csv.NewWriter(csvFile)
+	defer writer.Flush()
+
+	// Table 0: Heading - 7 columns, 2 rows
 	// heading: Invoice filename w/date, Device qty, Bill Total, Split Total
 	//   (for comparison), Usage subtotal, Devices Subtotal, Tax+Reg subtotal"
 
-	// Table 1: Usage - 8 rows
+	// Prep data
+	minCosts := decimal.New(0, 1)
+	msgCosts := decimal.New(0, 1)
+	megCosts := decimal.New(0, 1)
+	shrCosts := decimal.New(0, 1)
+
+	for _, v := range bs.MinuteCosts {
+		minCosts = minCosts.Add(v)
+	}
+
+	for _, v := range bs.MessageCosts {
+		msgCosts = msgCosts.Add(v)
+	}
+	for _, v := range bs.MegabyteCosts {
+		megCosts = megCosts.Add(v)
+	}
+	for _, v := range bs.SharedCosts {
+		shrCosts = shrCosts.Add(v)
+	}
+
+	calcCost := decimal.Sum(minCosts, msgCosts, megCosts, shrCosts).Round(RoundPrecision)
+	usgCost := decimal.Sum(minCosts, msgCosts, megCosts).Round(RoundPrecision)
+
+	records := [][]string{
+		{"Invoice with date", "Devices Qty", "$Total", "$Calc", "$Usage", "$Devices", "$Tax+Reg"},
+		{b.Description,
+			strconv.Itoa(len(b.Devices)),
+			strconv.FormatFloat(b.Total, 'f', 2, 64),
+			calcCost.StringFixed(2),
+			usgCost.StringFixed(2),
+			strconv.FormatFloat(b.DevicesCost, 'f', 2, 64),
+			strconv.FormatFloat(b.Fees, 'f', 2, 64)},
+	}
+
+	// Table 1: Usage - 8 columns, <deviceID qty>+1 rows
 	// heading: number, nickname?, min, msg, data (KB), min%, msg%, data%
 	// Then entries for each number
 	// then entry for "Total" under nickname, and rest of sums
 
-	// Table 2: Weighted costs - 3 rows
+	// Table 2: Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
 	// heading: Weighted Costs: Minutes, Messages, Data
 	// Base: $x, $y, $z
 	// Extra: etc
-	// Total: etc
+	// Total: etc (sum of Min, Msg, Data gets tacked on as extra cell/col on final row)
 
-	// Table 3: Shared costs - 2
-	// TODO LATER - handle all the tax and reg costs in bill file?
+	// Table 3: Shared costs - 2 columns, 4 rows
 	// heading: Type, Amount
+	// Devices: $
+	// Tax & Reg: $
+	// Total: $
 
-	// Table 4: Costs split - 7
+	// Table 4: Costs split - 7 columns, <deviceID qty>+1 rows
 	// heading: number, Nickname, Min, Msg, Data, Shared, Total
 	// entry for each number
+
+	err = writer.WriteAll(records)
 
 	return filePath, err
 }

--- a/internal/tingcsv/tingcsv.go
+++ b/internal/tingcsv/tingcsv.go
@@ -1,0 +1,40 @@
+package tingcsv
+
+import (
+	"fmt"
+
+	"github.com/hitjim/ting-bill-split/internal/tingbill"
+)
+
+// GenerateCSV accepts a tingbill.BillSplit, tingbill.Bill, filepath string, and returns a string
+// containing a filepath for the newly generated Ting Bill Split CSV, and an error.
+// The tingbill.Bill should be the same one that generated the tingbill.BillSplit
+func GenerateCSV(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (string, error) {
+	fmt.Printf("\nGenerating invoice CSV...\n")
+	RoundPrecision := int32(2)
+
+	// Table 0: Heading - 7 rows
+	// heading: Invoice filename w/date, Device qty, Bill Total, Split Total
+	//   (for comparison), Usage subtotal, Devices Subtotal, Tax+Reg subtotal"
+
+	// Table 1: Usage - 8 rows
+	// heading: number, nickname?, min, msg, data (KB), min%, msg%, data%
+	// Then entries for each number
+	// then entry for "Total" under nickname, and rest of sums
+
+	// Table 2: Weighted costs - 3 rows
+	// heading: Weighted Costs: Minutes, Messages, Data
+	// Base: $x, $y, $z
+	// Extra: etc
+	// Total: etc
+
+	// Table 3: Shared costs - 2
+	// TODO LATER - handle all the tax and reg costs in bill file?
+	// heading: Type, Amount
+
+	// Table 4: Costs split - 7
+	// heading: number, Nickname, Min, Msg, Data, Shared, Total
+	// entry for each number
+
+	return filePath, err
+}

--- a/internal/tingpdf/tingpdf.go
+++ b/internal/tingpdf/tingpdf.go
@@ -14,14 +14,14 @@ import (
 // The tingbill.Bill should be the same one that generated the tingbill.BillSplit.
 func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (string, error) {
 	fmt.Printf("\nGenerating invoice PDF...\n")
-	RoundPrecision := int32(2)
+	const RoundPrecision = int32(2)
 
 	pdf := gofpdf.New("P", "mm", "A4", "")
 	pdf.AddPage()
 	pdf.SetFont("Arial", "B", 10)
 	pdf.SetXY(10, 20)
 
-	// Table 0: Heading - 7 rows
+	// Table 0: Heading - 7 columns, 2 rows
 	// heading: Invoice filename w/date, Device qty, Bill Total, Split Total
 	//   (for comparison), Usage subtotal, Devices Subtotal, Tax+Reg subtotal"
 	headingTable := func(b tingbill.Bill, bs tingbill.BillSplit) {
@@ -77,7 +77,7 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	}
 	headingTable(b, bs)
 
-	// Table 1: Usage - 8 rows
+	// Table 1: Usage - 8 columns, <deviceID qty>+1 rows
 	// heading: number, nickname?, min, msg, data (KB), min%, msg%, data%
 	// Then entries for each number
 	// then entry for "Total" under nickname, and rest of sums
@@ -120,8 +120,6 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 			}
 		}
 
-		// TODO: turn this into some kind of getMapKeys if it gets too crazy
-
 		// Print data
 		pdf.SetXY(10, pdf.GetY())
 		var wi int
@@ -154,11 +152,11 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	}
 	usageTable(b, bs)
 
-	// Table 2: Weighted costs - 3 rows
-	// heading: Weighted Costs: Minutes, Messages, Data
+	// Table 2: Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
+	// heading: Cost Type: Minutes, Messages, Data
 	// Base: $x, $y, $z
 	// Extra: etc
-	// Total: etc
+	// Total: etc (sum of Min, Msg, Data gets tacked on as extra cell/col on final row)
 	weightedTable := func(b tingbill.Bill) {
 		type weightedTableVals struct {
 			name     string
@@ -223,9 +221,11 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	}
 	weightedTable(b)
 
-	// Table 3: Shared costs - 2
-	// TODO LATER - handle all the tax and reg costs in bill file?
+	// Table 3: Shared costs - 2 columns, 4 rows
 	// heading: Type, Amount
+	// Devices: $
+	// Tax & Reg: $
+	// Total: $
 	sharedTable := func(b tingbill.Bill) {
 		type sharedTableVals struct {
 			costType string
@@ -275,7 +275,7 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	}
 	sharedTable(b)
 
-	// Table 4: Costs split - 7
+	// Table 4: Costs split - 7 columns, <deviceID qty>+1 rows
 	// heading: number, Nickname, Min, Msg, Data, Shared, Total
 	// entry for each number
 	splitTable := func(bs tingbill.BillSplit) {

--- a/internal/tingpdf/tingpdf.go
+++ b/internal/tingpdf/tingpdf.go
@@ -10,10 +10,10 @@ import (
 )
 
 // GeneratePDF accepts a tingbill.BillSplit, tingbill.Bill, filepath string, and returns a string
-// containing a filepath for the new Ting Bill Split PDF and an error.
+// containing a filepath for the newly generated Ting Bill Split PDF, and an error.
 // The tingbill.Bill should be the same one that generated the tingbill.BillSplit.
 func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (string, error) {
-	fmt.Printf("\nGenerating invoice...\n")
+	fmt.Printf("\nGenerating invoice PDF...\n")
 	RoundPrecision := int32(2)
 
 	pdf := gofpdf.New("P", "mm", "A4", "")

--- a/internal/tingpdf/tingpdf.go
+++ b/internal/tingpdf/tingpdf.go
@@ -82,6 +82,8 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	// Then entries for each number
 	// then entry for "Total" under nickname, and rest of sums
 	usageTable := func(b tingbill.Bill, bs tingbill.BillSplit) {
+		// making this type made it just a little more readable once you start populating cells,
+		// especially needing to respect the order deviceIDs are entered on bill.toml
 		type usageTableVals struct {
 			id         string
 			owner      string
@@ -152,8 +154,8 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	}
 	usageTable(b, bs)
 
-	// Table 2: Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
-	// heading: Cost Type: Minutes, Messages, Data
+	// Table 2: Weighted Cost Type - 4 columns, 4 rows (+1 for cell to right of final column)
+	// heading: Weighted: Minutes, Messages, Data
 	// Base: $x, $y, $z
 	// Extra: etc
 	// Total: etc (sum of Min, Msg, Data gets tacked on as extra cell/col on final row)
@@ -165,7 +167,7 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 			data     string
 		}
 
-		wtheading := []string{"Cost Type", "Minutes", "Messages", "Data"}
+		wtheading := []string{"Weighted", "Minutes", "Messages", "Data"}
 		pdf.SetXY(10, pdf.GetY()+5)
 
 		// Print heading
@@ -222,7 +224,7 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 	weightedTable(b)
 
 	// Table 3: Shared costs - 2 columns, 4 rows
-	// heading: Type, Amount
+	// heading: Shared, Amount
 	// Devices: $
 	// Tax & Reg: $
 	// Total: $
@@ -232,7 +234,7 @@ func GeneratePDF(bs tingbill.BillSplit, b tingbill.Bill, filePath string) (strin
 			amount   string
 		}
 
-		stheading := []string{"Type", "Amount"}
+		stheading := []string{"Shared", "Amount"}
 		pdf.SetXY(10, pdf.GetY()+5)
 
 		// Print heading

--- a/test/bill.toml
+++ b/test/bill.toml
@@ -1,4 +1,4 @@
-description = "Ting Bill YYYY-MM-DD"
+description = "Ting Bill Split YYYY-MM-DD"
 
 total = 118.84
 

--- a/test/bill.toml
+++ b/test/bill.toml
@@ -10,7 +10,7 @@ megabytes = 20.00
 
 extraMinutes = 1.00
 extraMessages = 2.00
-extraMegabytes = 3.00
+extraMegabytes = 4.00
 
 fees = 28.74
 


### PR DESCRIPTION
In addition to the existing PDF report, we now generate a CSV report. This is handy for importing a monthly report to a tracking spreadsheet. For me, it's usually to give someone a heads up that they're streaming a lot while not on WIFI etc. They pay the cost, but it's a nice courtesy to provide :) 
* The first header value in a new table is `**Surrounded by Asterisks**` for readability
* The layout of the file mirrors the PDF report (some small tweaks were made the the PDF)
* We generate both PDF and CSV every time.

resolves #33 